### PR TITLE
Add app launcher icon docs

### DIFF
--- a/docs/test-and-publish/publish/apple-app-store-deployment.md
+++ b/docs/test-and-publish/publish/apple-app-store-deployment.md
@@ -13,10 +13,9 @@ keywords: [Apple App Store, Deployment, Dreamflow, iOS]
 Dreamflow allows you to deploy your apps directly to the Apple App Store from within the platform. This guide covers all the necessary prerequisites, a step-by-step deployment process, and common troubleshooting tips.
 
 :::info[Prerequisites]
-
+- Ensure you have [**set an app launcher icon**](pre-checks-publishing.md#add-app-launcher-icon).
 - Create an [**Apple account**](https://appleid.apple.com/account?appId=632&returnUrl=https%3A//developer.apple.com/account/).
 - [**Purchase an Apple Developer membership**](https://developer.apple.com/programs/enroll/). Learn more about the program and enrollment process [**here**](https://developer.apple.com/programs/).
-- Ensure you have set an app launcher icon. If not, add an app icon to the Dreamflow assets, then use the [**flutter_launcher_icons**](https://pub.dev/packages/flutter_launcher_icons) package or ask the AI agent to set it up for you.
 - Ensure your app bundle identifier is correct, as it cannot be changed after publishing. To update the bundle identifier, you can use the [**change_app_package_name**](https://pub.dev/packages/change_app_package_name) package or simply ask the AI agent.
 - It's recommended to [**test your app on a real device**](../test/test-on-mobile-device.md) before deployment.
 

--- a/docs/test-and-publish/publish/google-playstore-deployment.md
+++ b/docs/test-and-publish/publish/google-playstore-deployment.md
@@ -13,9 +13,8 @@ keywords: [Google Play Store, Deployment, Dreamflow, Android]
 Dreamflow allows you to deploy your apps directly to the Google Play Store from within the platform. This guide covers all the necessary prerequisites, a step-by-step deployment process, and common troubleshooting tips.
 
 :::info[Prerequisites]
-
+- Ensure you have [**set an app launcher icon**](pre-checks-publishing.md#add-app-launcher-icon).
 - Register for a [**Google Play Developer account**](https://play.google.com/console/signup).
-- Ensure you have set an app launcher icon. If not, add an app icon to the Dreamflow assets, then use the [**flutter_launcher_icons**](https://pub.dev/packages/flutter_launcher_icons) package or ask the AI agent to set it up for you.
 - Ensure your app package name is correct, as it cannot be changed after deployment. To verify it, open `android/app/build.gradle` and check the `applicationId`. To update the package name, you can use the [**change_app_package_name**](https://pub.dev/packages/change_app_package_name) package or simply ask the AI agent.
 - It's recommended to [**test your app on a real device**](../test/test-on-mobile-device.md) before deployment.
 

--- a/docs/test-and-publish/publish/pre-checks-publishing.md
+++ b/docs/test-and-publish/publish/pre-checks-publishing.md
@@ -28,3 +28,131 @@ Here’s a comprehensive list of these prechecks:
 10. **Prepare Marketing Assets**: Prepare all the necessary marketing assets, such as screenshots, app icons, and promotional text.
 11. **Error Logging & Monitoring**: Integrate crash reporting and analytics (e.g., Firebase Crashlytics, Sentry) before release. Try triggering test crashes in debug or staging builds to confirm reports are collected correctly.
 12. **Offline & Poor Network Support**: Validate app behavior with no connectivity and high-latency/packet-loss scenarios. Provide cached content, retry/backoff for API calls, and clear offline states.
+
+
+## Add App Launcher Icon
+
+An **app launcher icon** is the small image that represents your app on a device’s home screen. It’s the first visual element users see, so having a clear and properly designed icon is important for branding and user experience.
+
+When you create a new app in Dreamflow, it sets a default Dreamflow logo as the launcher icon. To give your app a unique identity, you should replace this with your own custom icon. Follow the steps below to update the launcher icon:
+
+1. Go to the [**Assets**](../../workspace/modules-panel/assets.md) module in Dreamflow and upload your icon image. For best results, use a square, high-resolution source image (i.e., **1024×1024 px**) to ensure your app icon looks sharp across all devices and sizes.
+2. Update the code to use the new app icon. Dreamflow uses the [`flutter_launcher_icons`](https://pub.dev/packages/flutter_launcher_icons) package to set launcher icons for both platforms. You can either:
+    - Ask the Agent to do it automatically, or
+    - Do it manually by updating the `image_path` in your `pubspec.yaml` file to point to the newly uploaded app icon.
+
+Here is the example configuration in `pubspec.yaml` file:
+
+```jsx
+flutter_launcher_icons:
+  android: true
+  ios: true
+  image_path: assets/images/app_icon.png
+  remove_alpha_ios: true
+```
+
+<div style={{
+    position: 'relative',
+    paddingBottom: 'calc(52.67989417989418% + 41px)', // Keeps the aspect ratio and additional padding
+    height: 0,
+    width: '100%'}}>
+    <iframe 
+        src="https://demo.arcade.software/xzNj2YwPUvpxlrNQCv1r?embed&show_copy_link=true"
+        title=""
+        style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            colorScheme: 'light'
+        }}
+        frameborder="0"
+        loading="lazy"
+        webkitAllowFullScreen
+        mozAllowFullScreen
+        allowFullScreen
+        allow="clipboard-write">
+    </iframe>
+</div>
+<p></p>
+
+:::info
+
+- The Agent can’t generate a launcher icon image for you; you need to upload your own image file in the **Assets** module.
+- The app icon is generated during native builds (Android/iOS) before deployment. However, if you want to verify that it’s configured correctly, [**download**](../test/test-on-mobile-device.md#download-code-and-run) the project, run the following command in the terminal, then run the app on a device and check device’s home screen to confirm the new icon appears.
+
+```jsx
+flutter pub run flutter_launcher_icons
+```
+:::
+
+### Platform-Specific Icon Configuration
+
+If you want to use different icons for Android and iOS, you can set platform-specific paths. This is useful if your design team provides unique assets for each platform.
+
+To do so, upload separate icons for each platform to assets module, then update your `pubspec.yaml` as shown below:
+
+```yaml
+flutter_launcher_icons:
+  android: true
+  ios: true
+  image_path_android: assets/images/app_icon_android.png
+  image_path_ios: assets/images/app_icon_ios.png
+  remove_alpha_ios: true
+
+```
+
+- **`image_path_android`**: Path to the Android app icon.
+- **`image_path_ios`**: Path to the iOS app icon.
+
+### Adaptive Icons for Android
+
+Android supports [**adaptive icons**](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#design-adaptive-icons), which allow your app icon to adapt to different shapes (circle, square, squircle, etc.). 
+
+To setup adaptive icons, you can either use this [online tool](https://icon.kitchen/) or use these [resources](#adaptive-icon-resources) to create one. and then provide both a **background** and **foreground** layer in `pubspec.yaml` file.
+
+Here is the example configuration:
+
+```jsx
+flutter_launcher_icons:
+  android: true
+  ios: true
+  image_path: "assets/icons/app_icon.png"
+
+  # For adaptive icon support:
+  adaptive_icon_background: "assets/icons/icon_bg.png"   # image or solid color ("#FFFFFF")
+  adaptive_icon_foreground: "assets/icons/icon_fg.png"   # your logo / symbol image
+  adaptive_icon_foreground_inset: 16   # optional padding percentage (default is 16)
+
+```
+
+- `adaptive_icon_background`: A solid color or image asset to use as the background layer.
+- `adaptive_icon_foreground`: An image asset to use as the foreground (your logo or symbol).
+- `adaptive_icon_foreground_inset` (optional): A padding percentage for the foreground layer.
+
+:::info
+
+- Both `adaptive_icon_background` and `adaptive_icon_foreground` must be set for adaptive icons to be generated.
+- If you do not specify adaptive layers, `flutter_launcher_icons` will fall back to generating legacy (non-adaptive) icons.
+
+:::
+
+
+#### Adaptive Icon Resources
+
+See the following resources for more information on Android adaptive icons.
+
+##### Create Adaptive Icon
+
+- [Create app icons in Android Studio](https://developer.android.com/studio/write/create-app-icons#create-adaptive)
+- [Figma template](https://material.uplabs.com/posts/adaptive-icon-sticker-sheet) (requires login)
+- [Bjango templates](https://github.com/bjango/Bjango-Templates) include adaptive icons
+- [Adobe XD template](https://github.com/faizmalkani/adaptive-icon-template-xd)
+
+##### Adaptive Icon Fundamentals
+
+- [Understanding Android Adaptive Icons](https://medium.com/google-design/understanding-android-adaptive-icons-cee8a9de93e2)
+- [Designing Adaptive Icons](https://medium.com/google-design/designing-adaptive-icons-515af294c783)
+- [Implementing Adaptive Icons](https://medium.com/google-developers/implementing-adaptive-icons-1e4d1795470e)
+


### PR DESCRIPTION
### Description
Add app launcher icon docs

[Linear ticket](https://linear.app/flutterflow/issue/DEVR-1124/add-information-about-adding-app-launcher-icons-to-before-deploying) and [magic word](https://linear.app/docs/github#link-prs) Fixes DEVR-1124  

## Type of change
- [ ] Typo fix 
- [x] New feature 
- [x] Enhancement to current docs
- [ ] Removed outdated references
- [ ] Update assets



